### PR TITLE
Dependency update (#70)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -76,6 +76,7 @@ jobs:
     name: Quay.io image builder & publisher
     needs: [build-node-versions, njsscan]
     runs-on: ubuntu-latest
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "@natlibfi/melinda-record-import-harvester-helmet",
-	"version": "1.0.1",
+	"version": "1.0.3-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-harvester-helmet",
-			"version": "1.0.1",
+			"version": "1.0.3-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.22.10",
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.5",
-				"@natlibfi/melinda-record-import-commons": "^10.1.7",
+				"@natlibfi/melinda-record-import-commons": "^10.1.8-alpha.1",
 				"http-status-codes": "^2.2.0",
 				"moment": "^2.29.4",
 				"node-fetch": "^2.6.12"
@@ -1753,9 +1753,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-			"integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+			"version": "7.22.11",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+			"integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2012,9 +2012,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.2.2.tgz",
-			"integrity": "sha512-yIlLMkopODmFO1a7nPlWmjGzhUEJSOScQ0C7DNcYpz3mBLB79Gs6WfZyjycABFkhquZ/MaiY3DO2E4WKVpMF9Q==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.3.1.tgz",
+			"integrity": "sha512-pN/7sHX+VeLhZNpEwp+RQAA4s2wcvab7axdmMpD81yVMBmLvruVMAiMyBXHAq4O39fTs5s/3o8FTme0dpctGzQ==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"jsonschema": "^1.4.1"
@@ -2024,11 +2024,11 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.6.tgz",
-			"integrity": "sha512-EXiJatZ7JFC9pk0e5eCh3CFvi54ONS+qQEqI1lQ5FpSSxLTWp18amlh9sZt7vDpJGuWzHpiGFWElo6qE2lIHpg==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.1.tgz",
+			"integrity": "sha512-vr1pfkY729DjRjWJCCrfGqJHCI+Etd1DZCYFxqYXXvyBRrDMgMqP01JXBhgwMDoMtQLynfAcFD/3no1rC/C5mA==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
+				"@natlibfi/marc-record": "^7.3.1",
 				"@xmldom/xmldom": "^0.8.10",
 				"stream-json": "^1.8.0",
 				"xml2js": ">=0.6.2 <1.0.0",
@@ -2063,36 +2063,36 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.5.tgz",
-			"integrity": "sha512-GLd53pe3zKoVCjIod3Dain5/QiubjslmAnTEi2PBKLk+bBYyL14MeAcsD21mUp23VM8QjwkMHT94ApGphVJQdA==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.6.tgz",
+			"integrity": "sha512-OnFCJfjWV9z3bj2u/pJDowtSDfsucXhAv/fN1sFgxGpYExY3fdTzDhu5WwM89t3I6uH3ILyp2HvhaKPUis8l8g==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^10.0.6",
+				"@natlibfi/marc-record": "^7.3.1",
+				"@natlibfi/marc-record-serializers": "^10.1.1",
 				"@natlibfi/sru-client": "^6.0.4",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"nock": "^13.3.2",
-				"node-fetch": "^2.6.12"
+				"nock": "^13.3.3",
+				"node-fetch": "^2.7.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "10.1.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.7.tgz",
-			"integrity": "sha512-qFG0gG8ucEMBpBOV39mZF5gExPvTmSFwnZvruArBm+8ngoKgau7fuRUfjhGj21QxLtWKXry4oX3VKo7jtq/7jA==",
+			"version": "10.1.8-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.8-alpha.1.tgz",
+			"integrity": "sha512-IQTBPEriLHgOwLdO7K4hLbmsa3A+/0w/lElERURvmYTKaUzk8azRQEePfbtJYzLOKrQzjeNFaGv8whWkZ0i4lA==",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
-				"@natlibfi/melinda-commons": "^13.0.5",
-				"amqplib": ">=0.10.3 <1.0.0",
+				"@natlibfi/melinda-commons": "^13.0.6",
+				"amqplib": "^0.10.3",
 				"debug": "^4.3.4",
 				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"node-fetch": "^2.6.12",
+				"node-fetch": "^2.7.0",
 				"rimraf": "^3.0.2",
 				"uuid": "^9.0.0",
 				"yargs": "^17.7.2"
@@ -5193,9 +5193,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
-			"integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
+			"version": "13.3.3",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.3.tgz",
+			"integrity": "sha512-z+KUlILy9SK/RjpeXDiDUEAq4T94ADPHE3qaRkf66mpEhzc/ytOMm3Bwdrbq6k1tMWkbdujiKim3G2tfQARuJw==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
@@ -5226,9 +5226,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-harvester-helmet.git"
 	},
 	"license": "MIT",
-	"version": "1.0.1",
+	"version": "1.0.3-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=16"
@@ -35,7 +35,7 @@
 		"@babel/runtime": "^7.22.10",
 		"@natlibfi/melinda-backend-commons": "^2.2.1",
 		"@natlibfi/melinda-commons": "^13.0.5",
-		"@natlibfi/melinda-record-import-commons": "^10.1.7",
+		"@natlibfi/melinda-record-import-commons": "^10.1.8-alpha.1",
 		"http-status-codes": "^2.2.0",
 		"moment": "^2.29.4",
 		"node-fetch": "^2.6.12"


### PR DESCRIPTION
* Bump @natlibfi/melinda-commons from 13.0.5 to 13.0.6 (#69)

Bumps [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js) from 13.0.5 to 13.0.6.
- [Release notes](https://github.com/natlibfi/melinda-commons-js/releases)
- [Commits](https://github.com/natlibfi/melinda-commons-js/compare/v13.0.5...v13.0.6)

---
updated-dependencies:
- dependency-name: "@natlibfi/melinda-commons" dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump @babel/runtime from 7.22.10 to 7.22.11 (#68)

Bumps [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) from 7.22.10 to 7.22.11.
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.22.11/packages/babel-runtime)

---
updated-dependencies:
- dependency-name: "@babel/runtime" dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump node-fetch from 2.6.12 to 2.7.0 (#67)

Bumps [node-fetch](https://github.com/node-fetch/node-fetch) from 2.6.12 to 2.7.0.
- [Release notes](https://github.com/node-fetch/node-fetch/releases)
- [Commits](https://github.com/node-fetch/node-fetch/compare/v2.6.12...v2.7.0)

---
updated-dependencies:
- dependency-name: node-fetch dependency-type: direct:production update-type: version-update:semver-minor ...




* Do not run quayio for dependabot RPs
* Update record-import-commons: v10.1.8-alpha.1
---------