### PR TITLE
Dependency update (#99, #103)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@natlibfi/melinda-record-import-harvester-helmet",
-	"version": "1.0.4",
+	"version": "1.0.5-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-harvester-helmet",
-			"version": "1.0.4",
+			"version": "1.0.5-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.23.8",
-				"@natlibfi/melinda-backend-commons": "^2.2.5",
-				"@natlibfi/melinda-commons": "^13.0.10",
+				"@natlibfi/melinda-backend-commons": "^2.2.6",
+				"@natlibfi/melinda-commons": "^13.0.11",
 				"@natlibfi/melinda-record-import-commons": "^10.2.2",
 				"http-status-codes": "^2.3.0",
 				"moment": "^2.30.1",
@@ -23,15 +23,15 @@
 				"@babel/node": "^7.22.19",
 				"@babel/preset-env": "^7.23.8",
 				"@babel/register": "^7.23.7",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 				"babel-plugin-istanbul": "^6.1.1",
 				"babel-plugin-rewire": "^1.2.0",
-				"chai": "^4.4.0",
+				"chai": "^4.4.1",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.56.0",
 				"eslint-plugin-import": "^2.29.1",
 				"mocha": "^10.2.0",
-				"nodemon": "^3.0.2",
+				"nodemon": "^3.0.3",
 				"nyc": "^15.1.0"
 			},
 			"engines": {
@@ -268,9 +268,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
+			"integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -1969,13 +1969,13 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -2018,9 +2018,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -2087,9 +2087,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -2097,9 +2097,9 @@
 			}
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.3.tgz",
-			"integrity": "sha512-tkfBuhpQ59D/TXBq+a0ntw0tdjS8h2rd59WF7pbASz/V/yBIwAgArZ+f1cVC8ybDsBlcZsLTb/v5V/7DxExBCw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.4.tgz",
+			"integrity": "sha512-0empL237DfX80LCFC7+pMXojsfMThBblViIT1MUllyYF0yNvmGSFTL1Ycf/HDfz61uX3MxJhE+ab3mQUWZpM3w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.22.15",
@@ -2115,9 +2115,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.0.2.tgz",
-			"integrity": "sha512-aCF5zgzlZ6YsQpGpJEpEfb0t/5gF4pl8exT0R/lFUxp63VkHz0OoX0mhRDhC0UYf4JufkrvkNMK2WwZFTSAT2Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.0.tgz",
+			"integrity": "sha512-kezWNVlOsBNdETT5xvoVU5d1308duKg/UebhXMavjDPbNO0IdoWRcFKUvS8ThV0hiVQ7ErlxK5DwnSJY25nODw==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"jsonschema": "^1.4.1"
@@ -2145,9 +2145,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.5.tgz",
-			"integrity": "sha512-XbCYwBBnNdhGzhNKgA619u4yVVtI8MU5RmgWqdJwME6m1xvafRITPvYdjU1DlHgYPZ+F+cj/qfbvamw4/UkLdw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.6.tgz",
+			"integrity": "sha512-BlAfjt1VH789dqmvMzKqGG8Gwj2TCkMGTiQ9FOIxbmWg1Wb6C6/OJCDSshB0JW7XNMMiVS4ZkOfDrOt4q1kmgA==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
@@ -2166,9 +2166,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.10",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.10.tgz",
-			"integrity": "sha512-6c+oh8Qll0uUUxcxDojb05Reffss3XH9lVFXPwdvylpInRZ9keHE9vrOuMgzGryOMpK5ddgTreKhpA7PYuhsLQ==",
+			"version": "13.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.11.tgz",
+			"integrity": "sha512-IQRpKfSMwfNcOldOnoyWGxAs8v6TPDNVUa/mOq3eh13aLtwQFG/uQIGWFJkGBiwIQcd+C12Y4mHFLqdQOkI8UA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.2",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
@@ -2176,8 +2176,8 @@
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.7.3",
-				"moment": "^2.29.4",
-				"nock": "^13.4.0",
+				"moment": "^2.30.1",
+				"nock": "^13.5.0",
 				"node-fetch": "^2.7.0"
 			},
 			"engines": {
@@ -2294,13 +2294,13 @@
 			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
-			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
+			"integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1"
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2311,13 +2311,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
-			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
+			"integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.18.1",
-				"@typescript-eslint/utils": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
+				"@typescript-eslint/utils": "6.19.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2338,9 +2338,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
-			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
+			"integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2351,13 +2351,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
-			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
+			"integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2412,17 +2412,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
-			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
+			"integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2470,12 +2470,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
-			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
+			"integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/types": "6.19.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2829,13 +2829,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
-			"integrity": "sha512-LidDk/tEGDfuHW2DWh/Hgo4rmnw3cduK6ZkOI1NPFceSK3n/yAGeOsNT7FLnSGHkXj3RHGSEVkN3FsCTY6w2CQ==",
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
+			"integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.4.4",
+				"@babel/helper-define-polyfill-provider": "^0.5.0",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2855,13 +2855,29 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.4.tgz",
-			"integrity": "sha512-S/x2iOCvDaCASLYsOOgWOq4bCfKYVqvO/uxjkaYyZ3rVsVE3CeAI/c84NpyuBBymEgNvHgjEot3a9/Z/kXvqsg==",
+		"node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
+			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.4"
+				"@babel/helper-compilation-targets": "^7.22.6",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/babel-plugin-polyfill-regenerator": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
+			"integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.5.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -3028,9 +3044,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001576",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-			"integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+			"version": "1.0.30001580",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+			"integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3048,9 +3064,9 @@
 			]
 		},
 		"node_modules/chai": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.0.tgz",
-			"integrity": "sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
@@ -3220,9 +3236,9 @@
 			"dev": true
 		},
 		"node_modules/core-js": {
-			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.0.tgz",
-			"integrity": "sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==",
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.1.tgz",
+			"integrity": "sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -3231,9 +3247,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.0.tgz",
-			"integrity": "sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==",
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+			"integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.22.2"
@@ -3411,9 +3427,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.625",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-			"integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
+			"version": "1.4.645",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
+			"integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -6291,9 +6307,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.4.0.tgz",
-			"integrity": "sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==",
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+			"integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
@@ -6360,9 +6376,9 @@
 			"dev": true
 		},
 		"node_modules/nodemon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
-			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+			"integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",
@@ -7331,13 +7347,13 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-			"integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.1",
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
 				"has-symbols": "^1.0.3",
 				"isarray": "^2.0.5"
 			},
@@ -7360,14 +7376,17 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/safe-regex-test": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+			"integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
 				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -7411,15 +7430,16 @@
 			"dev": true
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
 			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,27 @@
 {
 	"name": "@natlibfi/melinda-record-import-harvester-helmet",
-	"version": "1.0.5-alpha.1",
+	"version": "1.0.5-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-harvester-helmet",
-			"version": "1.0.5-alpha.1",
+			"version": "1.0.5-alpha.2",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.23.8",
+				"@babel/runtime": "^7.23.9",
 				"@natlibfi/melinda-backend-commons": "^2.2.6",
-				"@natlibfi/melinda-commons": "^13.0.11",
+				"@natlibfi/melinda-commons": "^13.0.12",
 				"@natlibfi/melinda-record-import-commons": "^10.2.2",
 				"http-status-codes": "^2.3.0",
 				"moment": "^2.30.1",
 				"node-fetch": "^2.7.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.23.4",
-				"@babel/core": "^7.23.7",
-				"@babel/node": "^7.22.19",
-				"@babel/preset-env": "^7.23.8",
+				"@babel/cli": "^7.23.9",
+				"@babel/core": "^7.23.9",
+				"@babel/node": "^7.23.9",
+				"@babel/preset-env": "^7.23.9",
 				"@babel/register": "^7.23.7",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 				"babel-plugin-istanbul": "^6.1.1",
@@ -74,9 +74,9 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.4.tgz",
-			"integrity": "sha512-j3luA9xGKCXVyCa5R7lJvOMM+Kc2JEnAEIgz2ggtjQ/j5YUVgfsg/WsG95bbsgq7YLHuiCOzMnoSasuY16qiCw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
+			"integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -125,9 +125,9 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
-			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+			"integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
@@ -135,11 +135,11 @@
 				"@babel/generator": "^7.23.6",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.7",
-				"@babel/parser": "^7.23.6",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6",
+				"@babel/helpers": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -155,9 +155,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz",
-			"integrity": "sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.9.tgz",
+			"integrity": "sha512-xPndlO7qxiJbn0ATvfXQBjCS7qApc9xmKHArgI/FTEFxXas5dnjC/VqM37lfZun9dclRYcn+YQAr6uDFy0bB2g==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -228,9 +228,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
-			"integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+			"integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -493,14 +493,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
-			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+			"integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6"
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -521,12 +521,12 @@
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.22.19",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.19.tgz",
-			"integrity": "sha512-VsKSO9aEHdO16NdtqkJfrXZ9Sxlna1BVnBbToWr1KGdI3cyIk6KqOoa8mWvpK280lJDOwJqxvnl994KmLhq1Yw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.23.9.tgz",
+			"integrity": "sha512-/d4ju/POwlGIJlZ+NqWH1qu61wt6ZlTZZZutrK2MOSdaH1JCh726nLw/GSvAjG+LTY6CO9SsB8uWcttnFKm6yg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/register": "^7.22.15",
+				"@babel/register": "^7.23.7",
 				"commander": "^4.0.1",
 				"core-js": "^3.30.2",
 				"node-environment-flags": "^1.0.5",
@@ -544,9 +544,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -866,9 +866,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
-			"integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+			"integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -1224,9 +1224,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
-			"integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+			"integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.22.5",
@@ -1623,9 +1623,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
-			"integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
@@ -1655,7 +1655,7 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.9",
 				"@babel/plugin-transform-async-to-generator": "^7.23.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
 				"@babel/plugin-transform-block-scoping": "^7.23.4",
@@ -1677,7 +1677,7 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
 				"@babel/plugin-transform-modules-amd": "^7.23.3",
 				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.23.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.23.9",
 				"@babel/plugin-transform-modules-umd": "^7.23.3",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
 				"@babel/plugin-transform-new-target": "^7.23.3",
@@ -1703,9 +1703,9 @@
 				"@babel/plugin-transform-unicode-regex": "^7.23.3",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.7",
-				"babel-plugin-polyfill-corejs3": "^0.8.7",
-				"babel-plugin-polyfill-regenerator": "^0.5.4",
+				"babel-plugin-polyfill-corejs2": "^0.4.8",
+				"babel-plugin-polyfill-corejs3": "^0.9.0",
+				"babel-plugin-polyfill-regenerator": "^0.5.5",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -1756,9 +1756,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+			"integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -1767,23 +1767,23 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
@@ -1792,8 +1792,8 @@
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -1802,9 +1802,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
@@ -2166,11 +2166,11 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.11",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.11.tgz",
-			"integrity": "sha512-IQRpKfSMwfNcOldOnoyWGxAs8v6TPDNVUa/mOq3eh13aLtwQFG/uQIGWFJkGBiwIQcd+C12Y4mHFLqdQOkI8UA==",
+			"version": "13.0.12",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.12.tgz",
+			"integrity": "sha512-Vl+xr7dcZy+URYCEyWBm9pDJyJBoDzTSxHIb8CMCgMA6KI/3YrPkUkaL3Yz0hLWgdo8fUKDMRKErjTv8am9P7w==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.2",
+				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/sru-client": "^6.0.8",
 				"debug": "^4.3.4",
@@ -2843,29 +2843,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
-			"integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+			"integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.4",
-				"core-js-compat": "^3.33.1"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"debug": "^4.1.1",
-				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2"
+				"@babel/helper-define-polyfill-provider": "^0.5.0",
+				"core-js-compat": "^3.34.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -3427,9 +3411,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.645",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
-			"integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==",
+			"version": "1.4.647",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.647.tgz",
+			"integrity": "sha512-Z/fTNGwc45WrYQhPaEcz5tAJuZZ8G7S/DBnhS6Kgp4BxnS40Z/HqlJ0hHg3Z79IGVzuVartIlTcjw/cQbPLgOw==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-harvester-helmet.git"
 	},
 	"license": "MIT",
-	"version": "1.0.5-alpha.1",
+	"version": "1.0.5-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=16"
@@ -33,19 +33,19 @@
 		"dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test nodemon"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.23.8",
+		"@babel/runtime": "^7.23.9",
 		"@natlibfi/melinda-backend-commons": "^2.2.6",
-		"@natlibfi/melinda-commons": "^13.0.11",
+		"@natlibfi/melinda-commons": "^13.0.12",
 		"@natlibfi/melinda-record-import-commons": "^10.2.2",
 		"http-status-codes": "^2.3.0",
 		"moment": "^2.30.1",
 		"node-fetch": "^2.7.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.23.4",
-		"@babel/core": "^7.23.7",
-		"@babel/node": "^7.22.19",
-		"@babel/preset-env": "^7.23.8",
+		"@babel/cli": "^7.23.9",
+		"@babel/core": "^7.23.9",
+		"@babel/node": "^7.23.9",
+		"@babel/preset-env": "^7.23.9",
 		"@babel/register": "^7.23.7",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 		"babel-plugin-istanbul": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-harvester-helmet.git"
 	},
 	"license": "MIT",
-	"version": "1.0.4",
+	"version": "1.0.5-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=16"
@@ -34,8 +34,8 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.23.8",
-		"@natlibfi/melinda-backend-commons": "^2.2.5",
-		"@natlibfi/melinda-commons": "^13.0.10",
+		"@natlibfi/melinda-backend-commons": "^2.2.6",
+		"@natlibfi/melinda-commons": "^13.0.11",
 		"@natlibfi/melinda-record-import-commons": "^10.2.2",
 		"http-status-codes": "^2.3.0",
 		"moment": "^2.30.1",
@@ -47,15 +47,15 @@
 		"@babel/node": "^7.22.19",
 		"@babel/preset-env": "^7.23.8",
 		"@babel/register": "^7.23.7",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 		"babel-plugin-istanbul": "^6.1.1",
 		"babel-plugin-rewire": "^1.2.0",
-		"chai": "^4.4.0",
+		"chai": "^4.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.56.0",
 		"eslint-plugin-import": "^2.29.1",
 		"mocha": "^10.2.0",
-		"nodemon": "^3.0.2",
+		"nodemon": "^3.0.3",
 		"nyc": "^15.1.0"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
* Bump the production-dependencies group with 2 updates (#97) Bumps the production-dependencies group with 2 updates: [@natlibfi/melinda-backend-commons](https://github.com/natlibfi/melinda-backend-commons-js) and [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js).

* Bump the development-dependencies group with 2 updates (#98) Bumps the development-dependencies group with 2 updates: [chai](https://github.com/chaijs/chai) and [nodemon](https://github.com/remy/nodemon).

* Update deps

* 1.0.5-alpha.1