### PR TITLE
Dependency update (#160)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@master
@@ -49,7 +49,7 @@ jobs:
     container: docker://node:22
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: mikaelvesavuori/license-compliance-action@v1
         with:
           exclude_pattern: /^@natlibfi/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@natlibfi/melinda-record-import-harvester-helmet",
-	"version": "1.0.9",
+	"version": "2.0.1-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-harvester-helmet",
-			"version": "1.0.9",
+			"version": "2.0.1-alpha.1",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
-				"@natlibfi/melinda-record-import-commons": "^13.0.0",
+				"@natlibfi/melinda-backend-commons": "^3.0.1",
+				"@natlibfi/melinda-commons": "^14.0.1",
+				"@natlibfi/melinda-record-import-commons": "^13.0.1",
 				"http-status": "^2.1.0",
 				"moment": "^2.30.1",
 				"yargs": "^18.0.0"
@@ -21,7 +21,7 @@
 			},
 			"devDependencies": {
 				"cross-env": "^10.1.0",
-				"esbuild": "^0.27.0",
+				"esbuild": "^0.27.1",
 				"eslint": "^9.39.1"
 			},
 			"engines": {
@@ -56,9 +56,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-			"integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+			"integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -73,9 +73,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-			"integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+			"integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
 			"cpu": [
 				"arm"
 			],
@@ -90,9 +90,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-			"integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+			"integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -107,9 +107,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-			"integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+			"integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-			"integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+			"integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-			"integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+			"integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
 			"cpu": [
 				"x64"
 			],
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
 			"cpu": [
 				"arm64"
 			],
@@ -175,9 +175,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-			"integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+			"integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
 			"cpu": [
 				"x64"
 			],
@@ -192,9 +192,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-			"integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+			"integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
 			"cpu": [
 				"arm"
 			],
@@ -209,9 +209,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-			"integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+			"integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -226,9 +226,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-			"integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+			"integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
 			"cpu": [
 				"ia32"
 			],
@@ -243,9 +243,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-			"integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+			"integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
 			"cpu": [
 				"loong64"
 			],
@@ -260,9 +260,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-			"integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+			"integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -277,9 +277,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-			"integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+			"integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -294,9 +294,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-			"integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+			"integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -311,9 +311,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-			"integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+			"integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
 			"cpu": [
 				"s390x"
 			],
@@ -328,9 +328,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-			"integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+			"integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
 			"cpu": [
 				"x64"
 			],
@@ -345,9 +345,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -362,9 +362,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-			"integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+			"integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
 			"cpu": [
 				"x64"
 			],
@@ -379,9 +379,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
 			"cpu": [
 				"arm64"
 			],
@@ -396,9 +396,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-			"integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+			"integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
 			"cpu": [
 				"x64"
 			],
@@ -413,9 +413,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-			"integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+			"integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -430,9 +430,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-			"integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+			"integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
 			"cpu": [
 				"x64"
 			],
@@ -447,9 +447,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-			"integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+			"integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
 			"cpu": [
 				"arm64"
 			],
@@ -464,9 +464,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-			"integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+			"integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -481,9 +481,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-			"integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+			"integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
 			"cpu": [
 				"x64"
 			],
@@ -581,9 +581,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -593,7 +593,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
+				"js-yaml": "^4.1.1",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -694,18 +694,18 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.2.tgz",
-			"integrity": "sha512-QgA5AySqB27cGTXBFmnpifAi7HxoGUeezwo6p9dI03MuDB6Pp33zgclqVb6oVK3j6I9Vesg0+oojW2XxB59SGg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.0.tgz",
+			"integrity": "sha512-ZHzx7Z3rdlWL1mECydvpryWN/ETXJiCxdgQKTAH+djzIPe77HdnSizKBDi1TVDXZjXyOj2IqEG/vPw71ULF06w==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.0.tgz",
-			"integrity": "sha512-675EZoyFhtL0YQzPDZOlcncZIjwXKa4QzaWoIg8MordC8mYaogJ0Xb4vGOeGglRVpvFA5ZwadgMs07EaJ+Cymw==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.1.tgz",
+			"integrity": "sha512-ENEMr0sMyM/LUViZ/+/SKQq/u9gju8GBKY4Rx+NsQ1JhV69F0/YbURropawG6eZHZJx0IlO7ncYZPJ6DfqWFHQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",
@@ -716,12 +716,12 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.0.tgz",
-			"integrity": "sha512-bl2Dtq9DgKPuh/h999a0q8IEfHWENaoGxZMDS/JP3OHrPqswnfA0k/xx1R9aCxccP8sViuPpdyCaerebxkBGUQ==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.1.tgz",
+			"integrity": "sha512-pIGJy/PGf7Sjkhh/AuNiKaltOzN7eyK0rt7vCayG8fPv5fQxAlP3Z8mC0CM62OKNetF+zHif5hXUxqPdKG6dJg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
 				"@xmldom/xmldom": "^0.9.8",
 				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
@@ -735,9 +735,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.0.tgz",
-			"integrity": "sha512-UhHV1TIpgPAFKRTJaGH3j7NIprT3adrw/k+mXiL0d79PH0NHBr+yi0yL8iZ3fnwqp1hIOOJjJ0CAKCk0YOxKAQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.1.tgz",
+			"integrity": "sha512-l8fFn/kG/M7i0+4Bisykchu73CkTT9BcqsJSgWJNw3P4GmwID6Ux9pn4srs7hI3TYH/059kpJONHfKAI9PmN7g==",
 			"license": "MIT",
 			"dependencies": {
 				"base64-url": "^2.3.3",
@@ -759,9 +759,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.0.tgz",
-			"integrity": "sha512-z6p4WJ2POG9qJ+K5X0LisLwnSQ/Lo89LodyL4DTCZq3i1EYPkl1IKq5anCEGdPUMlHbTDFIx5W554Junq1FugQ==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.1.tgz",
+			"integrity": "sha512-RJ4+w95octDoX5ifoUScIbYM8Bld38ziQdEag1AYBGDI/pRzA+20/KmxHPL8lDcbr5DlU+oUK4SLybZuyFmmwA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.0",
@@ -774,9 +774,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-13.0.0.tgz",
-			"integrity": "sha512-HgnlZ4IXYSm4CDgurHJbbnlaZa78nH9gUDeLujEnaa115Byy81vzl8UDeIA2gCHNBBYx4xa6jI7Q+QYfYOfQXQ==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-13.0.1.tgz",
+			"integrity": "sha512-HeMNE6A30eC3mxjEwKoAgNsEG5aWsMbbtUv32bVPymOv9RDHU9v/1X0SB9BAJMXM1cb3ctPRAkgdktQPb0/fzA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^3.0.0",
@@ -1036,13 +1036,13 @@
 			}
 		},
 		"node_modules/color": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
-			"integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
 			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^3.0.1",
-				"color-string": "^2.0.0"
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1069,9 +1069,9 @@
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
-			"integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "^2.0.0"
@@ -1081,18 +1081,18 @@
 			}
 		},
 		"node_modules/color-string/node_modules/color-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-			"integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
 			}
 		},
 		"node_modules/color/node_modules/color-convert": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
-			"integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "^2.0.0"
@@ -1102,9 +1102,9 @@
 			}
 		},
 		"node_modules/color/node_modules/color-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-			"integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
@@ -1273,9 +1273,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-			"integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+			"integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1286,32 +1286,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.0",
-				"@esbuild/android-arm": "0.27.0",
-				"@esbuild/android-arm64": "0.27.0",
-				"@esbuild/android-x64": "0.27.0",
-				"@esbuild/darwin-arm64": "0.27.0",
-				"@esbuild/darwin-x64": "0.27.0",
-				"@esbuild/freebsd-arm64": "0.27.0",
-				"@esbuild/freebsd-x64": "0.27.0",
-				"@esbuild/linux-arm": "0.27.0",
-				"@esbuild/linux-arm64": "0.27.0",
-				"@esbuild/linux-ia32": "0.27.0",
-				"@esbuild/linux-loong64": "0.27.0",
-				"@esbuild/linux-mips64el": "0.27.0",
-				"@esbuild/linux-ppc64": "0.27.0",
-				"@esbuild/linux-riscv64": "0.27.0",
-				"@esbuild/linux-s390x": "0.27.0",
-				"@esbuild/linux-x64": "0.27.0",
-				"@esbuild/netbsd-arm64": "0.27.0",
-				"@esbuild/netbsd-x64": "0.27.0",
-				"@esbuild/openbsd-arm64": "0.27.0",
-				"@esbuild/openbsd-x64": "0.27.0",
-				"@esbuild/openharmony-arm64": "0.27.0",
-				"@esbuild/sunos-x64": "0.27.0",
-				"@esbuild/win32-arm64": "0.27.0",
-				"@esbuild/win32-ia32": "0.27.0",
-				"@esbuild/win32-x64": "0.27.0"
+				"@esbuild/aix-ppc64": "0.27.1",
+				"@esbuild/android-arm": "0.27.1",
+				"@esbuild/android-arm64": "0.27.1",
+				"@esbuild/android-x64": "0.27.1",
+				"@esbuild/darwin-arm64": "0.27.1",
+				"@esbuild/darwin-x64": "0.27.1",
+				"@esbuild/freebsd-arm64": "0.27.1",
+				"@esbuild/freebsd-x64": "0.27.1",
+				"@esbuild/linux-arm": "0.27.1",
+				"@esbuild/linux-arm64": "0.27.1",
+				"@esbuild/linux-ia32": "0.27.1",
+				"@esbuild/linux-loong64": "0.27.1",
+				"@esbuild/linux-mips64el": "0.27.1",
+				"@esbuild/linux-ppc64": "0.27.1",
+				"@esbuild/linux-riscv64": "0.27.1",
+				"@esbuild/linux-s390x": "0.27.1",
+				"@esbuild/linux-x64": "0.27.1",
+				"@esbuild/netbsd-arm64": "0.27.1",
+				"@esbuild/netbsd-x64": "0.27.1",
+				"@esbuild/openbsd-arm64": "0.27.1",
+				"@esbuild/openbsd-x64": "0.27.1",
+				"@esbuild/openharmony-arm64": "0.27.1",
+				"@esbuild/sunos-x64": "0.27.1",
+				"@esbuild/win32-arm64": "0.27.1",
+				"@esbuild/win32-ia32": "0.27.1",
+				"@esbuild/win32-x64": "0.27.1"
 			}
 		},
 		"node_modules/escalade": {
@@ -1848,18 +1848,18 @@
 			"license": "ISC"
 		},
 		"node_modules/jose": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.1.tgz",
-			"integrity": "sha512-GWSqjfOPf4cWOkBzw5THBjtGPhXKqYnfRBzh4Ni+ArTrQQ9unvmsA3oFLqaYKoKe5sjWmGu5wVKg9Ft1i+LQfg==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2019,9 +2019,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-			"integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+			"integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.3.0",
@@ -2088,18 +2088,18 @@
 			"license": "MIT"
 		},
 		"node_modules/nodemailer": {
-			"version": "7.0.10",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
-			"integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+			"integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/oauth4webapi": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.2.tgz",
-			"integrity": "sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+			"integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -2553,9 +2553,9 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.18.3",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
-			"integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
 			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-harvester-helmet.git"
 	},
 	"license": "MIT",
-	"version": "1.0.9",
+	"version": "2.0.1-alpha.1",
 	"main": "./dist/index.js",
 	"type": "module",
 	"bin": "./dist/cli.js",
@@ -27,23 +27,23 @@
 		"cli": "node ./dist/cli.js",
 		"lint": "eslint ./src",
 		"lint:dev": "eslint --fix ./src",
-		"test:base": "node --test --test-force-exit --experimental-test-coverage --test-reporter=spec './src/*.test.js' './src/**/*.test.js'",
+		"test:base": "node --test --test-force-exit --experimental-test-coverage --test-reporter=spec './src/**/*.test.js'",
 		"test": "npm run lint && npm run test:base",
-		"watch:test": "cross-env DEBUG=@natlibfi/* NODE_ENV=test node --watch --test --experimental-test-coverage --test-reporter=spec './src/*.test.js' './src/**/*.test.js'",
+		"watch:test": "cross-env DEBUG=@natlibfi/* NODE_ENV=test node --watch --test --experimental-test-coverage --test-reporter=spec './src/**/*.test.js'",
 		"dev": "npm run watch:test",
 		"dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test npm run watch:test"
 	},
 	"dependencies": {
-		"@natlibfi/melinda-backend-commons": "^3.0.0",
-		"@natlibfi/melinda-commons": "^14.0.0",
-		"@natlibfi/melinda-record-import-commons": "^13.0.0",
+		"@natlibfi/melinda-backend-commons": "^3.0.1",
+		"@natlibfi/melinda-commons": "^14.0.1",
+		"@natlibfi/melinda-record-import-commons": "^13.0.1",
 		"http-status": "^2.1.0",
 		"moment": "^2.30.1",
 		"yargs": "^18.0.0"
 	},
 	"devDependencies": {
 		"cross-env": "^10.1.0",
-		"esbuild": "^0.27.0",
+		"esbuild": "^0.27.1",
 		"eslint": "^9.39.1"
 	}
 }


### PR DESCRIPTION
* Bump esbuild from 0.27.0 to 0.27.1 in the development-dependencies group (#159)

* Bump the production-dependencies group with 3 updates (#158) Updates `@natlibfi/melinda-backend-commons` from 3.0.0 to 3.0.1

* Bump actions/checkout from 5 to 6 (#157)

* Bump nodemailer from 7.0.10 to 7.0.11 (#156)

* Bump js-yaml from 4.1.0 to 4.1.1 (#155)

* Update deps; fix test script

* 2.0.1-alpha.1